### PR TITLE
Bunch of fixes for `dub test`

### DIFF
--- a/src/quic/attributes.d
+++ b/src/quic/attributes.d
@@ -13,14 +13,6 @@ template getFixedLength(T)
 
 enum hasFixedLength(T) = is(T == FixedLength!len, uint len);
 
-template getEstablishedLength(T)
-{
-    static if(is(T == EstablishedLength!len, uint len))
-        enum getEstablishedLength = len;
-}
-
-enum hasEstablishedLength(alias T) = is(T) && is(T == FixedLength!len, uint len);
-
 template getTlsFrameType(T)
 {
     static if(is(T == TlsFrame!type, int type))

--- a/src/quic/attributes.d
+++ b/src/quic/attributes.d
@@ -1,10 +1,9 @@
 module quic.attributes;
 
-struct VarIntLength {};
-struct FixedLength(uint len) {};
-struct EstablishedLength(uint len) {};
-struct TlsFrame(int type) {};
-struct TlsExtension(int type) {};
+struct VarIntLength {}
+struct FixedLength(uint len) {}
+struct TlsFrame(int type) {}
+struct TlsExtension(int type) {}
 
 template getFixedLength(T)
 {
@@ -12,7 +11,7 @@ template getFixedLength(T)
         enum getFixedLength = len;
 }
 
-enum hasFixedLength(alias T) = is(T) && is(T == FixedLength!len, uint len);
+enum hasFixedLength(T) = is(T == FixedLength!len, uint len);
 
 template getEstablishedLength(T)
 {
@@ -28,7 +27,7 @@ template getTlsFrameType(T)
         enum getTlsFrameType = type;
 }
 
-enum isTlsFrame(alias T) = is(T) && is(T == TlsFrame!type, int type);
+enum isTlsFrame(T) = is(T == TlsFrame!type, int type);
 
 template getTlsExtensionType(T)
 {
@@ -36,4 +35,4 @@ template getTlsExtensionType(T)
         enum getTlsExtensionType = type;
 }
 
-enum isTlsExtension(alias T) = is(T) && is(T == TlsFrame!type, int type);
+enum isTlsExtension(T) = is(T == TlsExtension!type, int type);

--- a/src/quic/connection.d
+++ b/src/quic/connection.d
@@ -110,8 +110,8 @@ struct TLSContext
     {
         if (state == TlsStates.clientHandshakeStart)
         {
-            clientHello helloFrame;
-            keyShare keyFrame;
+            ClientHello helloFrame;
+            KeyShare keyFrame;
             keyFrame.publicKey = publicKey;
             writer.getBytes(helloFrame.extensionData, keyFrame);
             writer.getBytes(buffer, helloFrame);
@@ -123,7 +123,7 @@ struct TLSContext
         if (state == TlsStates.clientExpectServerHello)
         {
             ulong tlsFrameIndex;
-            auto reader = QuicReader!(serverHello)(message, tlsFrameIndex);
+            auto reader = QuicReader!ServerHello(message, tlsFrameIndex);
             if (readBigEndianField(message, tlsFrameIndex, 2) == TlsFrameTypes.serverHello)
             {
                 reader.legacy_version;
@@ -142,7 +142,7 @@ struct TLSContext
         if (readBigEndianField(message, extensionIndex, 2) ==
                                                 TlsExtensionTypes.keyShare)
         {
-            auto reader = QuicReader!(keyShare)(message, extensionIndex);
+            auto reader = QuicReader!KeyShare(message, extensionIndex);
             reader.groups;
             generateSharedKey(reader.publicKey[], privateKey[], sharedKey);
         }

--- a/src/quic/connection.d
+++ b/src/quic/connection.d
@@ -1,3 +1,5 @@
+module quic.connection;
+
 import quic.frame_writer;
 import quic.frame_reader;
 import quic.packet;

--- a/src/quic/connection.d
+++ b/src/quic/connection.d
@@ -144,7 +144,7 @@ struct TLSContext
         {
             auto reader = QuicReader!(keyShare)(message, extensionIndex);
             reader.groups;
-            generateSharedKey(reader.publicKey, privateKey, sharedKey);
+            generateSharedKey(reader.publicKey[], privateKey[], sharedKey);
         }
     }
 }

--- a/src/quic/crypto.d
+++ b/src/quic/crypto.d
@@ -323,6 +323,8 @@ out (result) {
                                             null, privateKey.ptr, len), null);
     else static if (is (Tpriv == EVP_PKEY*))
         auto pctx = EVP_PKEY_CTX_new(privateKey, null);
+    else
+        static assert(false, "Invalid private key type: " ~ Tpriv.stringof);
 
     if (EVP_PKEY_derive_init(pctx) < 1)
         return -1;

--- a/src/quic/encode.d
+++ b/src/quic/encode.d
@@ -33,7 +33,7 @@ in {
     foreach (i, elem; bigEndianValue[$-len..$])
     {
         if (i == 0)
-            writer ~= elem | getVarIntBitMask(len);
+            writer ~= cast(ubyte)(elem | getVarIntBitMask(len));
         else
             writer ~= elem;
     }

--- a/src/quic/frame.d
+++ b/src/quic/frame.d
@@ -52,7 +52,7 @@ alias TlsData = ubyte[2];
 @TlsFrame!(TlsFrameTypes.clientHello) @FixedLength!3 struct ClientHello
 {
     uint legacy_version;
-    @EstablishedLength!32 ubyte[32] random;
+    ubyte[32] random;
     //not used by QUIC
     ubyte[] legacy_session_id = [0];
     //not used by QUIC
@@ -65,7 +65,7 @@ alias TlsData = ubyte[2];
 {
     ubyte frameType;
     uint legacy_version;
-    @EstablishedLength!32 ubyte[32] random;
+    ubyte[32] random;
     //not used by QUIC
     @FixedLength!1 ubyte[] legacy_compression_method = [0];
     @FixedLength!2 ubyte[] extensionData;

--- a/src/quic/frame.d
+++ b/src/quic/frame.d
@@ -1,12 +1,12 @@
 module quic.frame;
 import quic.attributes;
 
-enum tlsFrameTypes {
-    ClientHello, ServerHello
+enum TlsFrameTypes {
+    clientHello, serverHello
 }
 
-enum tlsExtensionTypes {
-   SupportedGroups = 10, SupportedVersions = 43, KeyShare = 51 
+enum TlsExtensionTypes {
+   supportedGroups = 10, supportedVersions = 43, keyShare = 51 
 }
 
 alias VarInt = ulong;
@@ -49,7 +49,7 @@ struct HandshakeDone
 
 alias TlsData = ubyte[2];
 
-@TlsFrame!(tlsFrameTypes.ClientHello) @FixedLength!3 struct ClientHello
+@TlsFrame!(TlsFrameTypes.clientHello) @FixedLength!3 struct ClientHello
 {
     uint legacy_version;
     @EstablishedLength!32 ubyte[32] random;
@@ -61,7 +61,7 @@ alias TlsData = ubyte[2];
     @FixedLength!2 ubyte[] extensionData;
 }
 
-@TlsFrame!(tlsFrameTypes.ServerHello) @FixedLength!3 struct ServerHello
+@TlsFrame!(TlsFrameTypes.serverHello) @FixedLength!3 struct ServerHello
 {
     ubyte frameType;
     uint legacy_version;
@@ -73,18 +73,18 @@ alias TlsData = ubyte[2];
 
 //Extensions
 
-@TlsExtension!(tlsExtensionTypes.SupportedVersions) @FixedLength!2 struct SupportedVersions
+@TlsExtension!(TlsExtensionTypes.supportedVersions) @FixedLength!2 struct SupportedVersions
 {
     //QUIC should support TLS 1.3 by default (0x03 0x04)
     @FixedLength!2 ubyte[] tlsVersions = [0x3, 0x4];
 }
 
-@TlsExtension!(tlsExtensionTypes.SupportedGroups) @FixedLength!2 struct SupportedGroups
+@TlsExtension!(TlsExtensionTypes.supportedGroups) @FixedLength!2 struct SupportedGroups
 {   //assigned value for the "x25519" elliptic-curve
     @FixedLength!2 ubyte[] groups = [0x00, 0x1d];
 }
 
-@TlsExtension!(tlsExtensionTypes.KeyShare) @FixedLength!2 struct KeyShare
+@TlsExtension!(TlsExtensionTypes.keyShare) @FixedLength!2 struct KeyShare
 {
     @FixedLength!2 ubyte[] groups = [0x00, 0x1d];
     @FixedLength!2 ubyte[] publicKey;

--- a/src/quic/frame_reader.d
+++ b/src/quic/frame_reader.d
@@ -17,6 +17,8 @@ struct QuicReader(FrameType)
         this.bufIndex = bufIndex;
     }
 
+    alias read = opDispatch;
+
     auto opDispatch(string name)() {
             alias FieldType = typeof(__traits(getMember, FrameType, name));
 

--- a/src/quic/frame_reader.d
+++ b/src/quic/frame_reader.d
@@ -68,10 +68,10 @@ struct QuicReader(FrameType)
                     return networkStream[bufIndex-len..bufIndex];
                 }
 
-                static if(hasFixedLengh!(attributes[0]))
+                static if(hasFixedLength!(attributes[0]))
                 {
                     auto lenOfLength = getFixedLength!(attributes[0]);
-                    auto len = readBigEndianField(networkStream, bufIndex, len);
+                    auto len = readBigEndianField(networkStream, bufIndex, lenOfLength);
                     bufIndex += len;
                     return networkStream[bufIndex-len..bufIndex];
                 }

--- a/src/quic/frame_reader.d
+++ b/src/quic/frame_reader.d
@@ -7,6 +7,7 @@ import quic.attributes;
 struct QuicReader(FrameType)
 {
     import quic.decode : decodeVarInt;
+    import std.traits;
 
     ubyte[] networkStream;
     ulong bufIndex;
@@ -81,6 +82,11 @@ struct QuicReader(FrameType)
             {
                 bufIndex += len;
                 return networkStream[bufIndex-len..bufIndex];
+            }
+
+            else static if (isIntegral!FieldType)
+            {
+                return readBigEndianField(networkStream, bufIndex, FieldType.sizeof);
             }
 
             else static assert(0, errorPrefix!() ~ " is not supported!");

--- a/src/quic/frame_reader.d
+++ b/src/quic/frame_reader.d
@@ -75,11 +75,10 @@ struct QuicReader(FrameType)
                 }
             }
 
-            else static if(hasEstablishedLength!(attributes[0]))
+            else static if (is(FieldType == ubyte[len], size_t len))
             {
-                    auto len = getEstablishedLength!(attributes[0]);
-                    bufIndex += len;
-                    return networkStream[bufIndex-len..bufIndex];
+                bufIndex += len;
+                return networkStream[bufIndex-len..bufIndex];
             }
 
             else static assert(0, errorPrefix!() ~ " is not supported!");

--- a/src/quic/frame_writer.d
+++ b/src/quic/frame_writer.d
@@ -41,10 +41,10 @@ struct QuicWriter
                 writeBigEndianField!(typeof(field).sizeof)(wLocal, field);
             }
 
-            else static if (attributes.length > 0)
+            else static if (attributes.length == 1)
             {
 
-                static if(is(attributes == VarIntLength))
+                static if(is(attributes[0] == VarIntLength))
                 {
                     encodeVarInt(wLocal, field.length);
                     wLocal ~= field;
@@ -62,6 +62,8 @@ struct QuicWriter
                 {
                     wLocal ~= field;
                 }
+
+                else static assert(0, "Type/Attribute combination is not supported");
             }
 
             else static if(is(typeof(field) == ubyte[]))
@@ -69,7 +71,7 @@ struct QuicWriter
                 wLocal ~= field;
             }
 
-            else assert(0, "Type is not supported");
+            else static assert(0, "Type is not supported");
         }
        
         alias frameAttrs = __traits(getAttributes, F);

--- a/src/quic/frame_writer.d
+++ b/src/quic/frame_writer.d
@@ -105,7 +105,7 @@ unittest
     import std.conv : hexString;
     import std.digest : toHexString, LetterCase;
 
-    QuicWriter writer;            
+    QuicWriter writer;
     InitialPacket packet;
     packet.headerBits = 0xc0;
     packet.destinationConnectionID = cast(ubyte[]) hexString!"0001020304050607";
@@ -114,5 +114,5 @@ unittest
     LocalAppender buffer;
     writer.getBytes(buffer, packet);
     assert(buffer[].toHexString!(LetterCase.lower) ==
-                                "c00000000108000102030405060705635f63696400");
+                                "c00000000108000102030405060705635f6369640000");
 }

--- a/src/quic/frame_writer.d
+++ b/src/quic/frame_writer.d
@@ -41,6 +41,12 @@ struct QuicWriter
                 writeBigEndianField!(typeof(field).sizeof)(wLocal, field);
             }
 
+            else static if(is(typeof(field) == ubyte[n], size_t n))
+            {
+                // implicit established length
+                wLocal ~= field[];
+            }
+
             else static if (attributes.length == 1)
             {
 
@@ -54,12 +60,6 @@ struct QuicWriter
                 {
                     writeBigEndianField!(getFixedLength!(attributes[0]))(wLocal,
                                                                 field.length);
-                    wLocal ~= field;
-                }
-
-                else static if (hasEstablishedLength!(attributes[0]) &&
-                                                        attributes.length > 0)
-                {
                     wLocal ~= field;
                 }
 

--- a/src/quic/packet.d
+++ b/src/quic/packet.d
@@ -46,7 +46,7 @@ mixin template BaseLongHeaderPacket()
 @VarIntLength struct ShortHeaderPacket(ulong len) //1-RTT packet
 {
     ubyte headerBits;
-    @EstablishedLength!(len) ubyte[len] destinationConnectionID;
+    ubyte[len] destinationConnectionID;
     ubyte[] packetPayload;
 }
 enum SampleOffset = 4;


### PR DESCRIPTION
I tried to build and test the project, but there were a bunch of issues.

I cleaned up the code according to D style, removed some unnecessary code and made the parsing more explicit.

I recommend going through the commits one-by-one.

If anything, I think at least 93b86675cf7606de80cbb71f472e9f4a11bbb4e4 is a must-have part of this PR, so if you decide against merging, please consider adding the changes from that. (It adds `.read!"property"` instead of the `.property` access to QuicReader, which tells the user that decoding is happening and that you can't/shouldn't access a property twice for proper reading)

I did not really read the QUIC RFC for these changes. There are definitely breaking changes in this PR. All the tests pass locally, so there should definitely be a bunch more tests based on the RFC.

I based my work on the devel-session branch, because that was most recently linked on the D forum and in the branches view it has the most work. I think you should definitely merge it into main, as main currently has no actual code in it and makes it hard to discover what's actually being done here.