### PR TITLE
Run CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
 
 jobs:
   main:


### PR DESCRIPTION
This avoids accidentally leaving branches half-finished or otherwise broken on github.